### PR TITLE
feat: add support for mariadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ The simple idea behind this plugin is to:
     POSTGRES_DB=TESTDB
     ```
 
-    - Mysql : `docker run -d --env-file .env.mysql -p 3306:3306 mysql:latest`
+    - Mysql (same for mariadb:latest): `docker run -d --env-file .env.mysql -p 3306:3306 mysql:latest`
 
     ```
-    # .env.mysql
+    # .env.mysql | or .env.mariadb
     MYSQL_DATABASE=TESTDB
     MYSQL_USER=u
     MYSQL_PASSWORD=p

--- a/lua/dockdb.lua
+++ b/lua/dockdb.lua
@@ -40,7 +40,6 @@ function M.RunMongoDBQuery()
     )
 end
 
--- TODO:
 -- On MariaDB execute query with the good set of config
 function M.RunMariaDBQuery()
     util.ExecuteWithOpts(

--- a/lua/mariadb.lua
+++ b/lua/mariadb.lua
@@ -2,20 +2,37 @@
 local M = {}
 
 -- Build a specific query on MariaDB with a given config
-function M.BuildMariaDBQuery(_, _)
-end
-
--- Execute a specific query on MariaDB with a given config
-function M.ExecuteMariaDBQuery(_, _)
+function M.BuildMariaDBQuery(sql_config, sql_query)
     print("MariaDB")
 
     -- docker run \
-    -- -e MYSQL_ROOT_PASSWORD=root \
+    -- -e MYSQL_DATABASE=TESTDB \
+    -- -e MYSQL_USER=u \
+    -- -e MYSQL_PASSWORD=p \
+    -- -e MYSQL_ROOT_PASSWORD=p \
     -- -d mariadb:latest
-    local image_name = 'mariadb'
-    local cli = 'mariadb'
 
-    error("NotImplemented :: ".. image_name .. " :: " .. cli)
+    local image_name = 'mariadb'
+    local sql_command = "bash -c 'MYSQL_PWD=".. sql_config.password ..
+        " mariadb" ..
+        " -h ".. sql_config.hostname ..
+        " -P ".. sql_config.port ..
+        " -u ".. sql_config.username ..
+        " -D ".. sql_config.database ..
+        "'"
+
+    return sql_query, sql_command, image_name
+end
+
+-- Execute a specific query on MariaDB with a given config
+function M.ExecuteMariaDBQuery(sql_config, sql_query)
+    local docker = require('docker')
+    docker.DockerExecute(
+        M.BuildMariaDBQuery(
+            sql_config,
+            sql_query
+        )
+    )
 end
 
 return M

--- a/tests/dockdb_test.lua
+++ b/tests/dockdb_test.lua
@@ -1,5 +1,6 @@
 local Docker = require('..lua.docker')
 local Mysql = require('..lua.mysql')
+local MariaDB = require('..lua.mariadb')
 local Postgresql = require('..lua.postgresql')
 local vim = {}
 vim.api = {}
@@ -38,6 +39,28 @@ describe('BuildMySQLQuery', function()
         local expected_image_name = 'mysql'
 
         local query, command, image_name = Mysql.BuildMySQLQuery(sql_config, sql_query)
+        assert.are.equal(expected_query, query)
+        assert.are.equal(expected_command, command)
+        assert.are.equal(expected_image_name, image_name)
+    end)
+end)
+
+describe('BuildMariaDBQuery', function()
+    it('should build a MariaDB query command with the given config', function()
+        local sql_config = {
+            hostname = 'localhost',
+            port = 3306,
+            username = 'user',
+            password = 'password',
+            database = 'my_database'
+        }
+        local sql_query = 'SELECT * FROM my_table'
+
+        local expected_query = 'SELECT * FROM my_table'
+        local expected_command = "bash -c 'MYSQL_PWD=password mariadb -h localhost -P 3306 -u user -D my_database'"
+        local expected_image_name = 'mariadb'
+
+        local query, command, image_name = MariaDB.BuildMariaDBQuery(sql_config, sql_query)
         assert.are.equal(expected_query, query)
         assert.are.equal(expected_command, command)
         assert.are.equal(expected_image_name, image_name)


### PR DESCRIPTION
## WHAT

Add support for mariadb

lucky it support the same API as Mysql.

## HOW

- **feat(mariadb): add support for mariadb engine**
- **feat(test): add testing for mariadb**
